### PR TITLE
Allow including some non-harmful pages in iframes

### DIFF
--- a/app/controllers/blog_controller.rb
+++ b/app/controllers/blog_controller.rb
@@ -2,6 +2,8 @@ class BlogController < ApplicationController
 
   layout 'static_blog_pages'
 
+  skip_before_filter :set_x_frame_options_header # For http://janpaulposma.nl/#factlink-lessons iframe (and others)
+
   def index
     render layout: 'static_pages'
   end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -12,6 +12,8 @@ class HomeController < ApplicationController
     end
   end
 
+  skip_before_filter :set_x_frame_options_header, only: [:index] # For janpaulposma.nl/#factlink iframe
+
   def index
     flash.keep
     if user_signed_in?


### PR DESCRIPTION
@martijnrusschen ?

Only allows inclusion of the homepage and blog pages in iframes. There should be no clickjacking possible on those pages.
